### PR TITLE
Bugfix - Prevent concurrent alchemy calls using a locking system

### DIFF
--- a/virtuals_acp/client.py
+++ b/virtuals_acp/client.py
@@ -304,7 +304,7 @@ class VirtualsACP:
         time.sleep(retry_delay)
         for attempt in range(retry_count):
             try:
-                response = self.contract_manager.validate_transaction(user_op_hash)
+                response = self.contract_manager.validate_transaction_with_lock(user_op_hash)
 
                 if response.get("status") == 200:
                     logs = response.get("receipts", [])[0].get("logs", [])

--- a/virtuals_acp/contract_manager.py
+++ b/virtuals_acp/contract_manager.py
@@ -46,6 +46,14 @@ class _ACPContractManager:
             return self.alchemy_kit.get_calls_status(hash_value)
         except Exception as e:
             raise Exception(f"Failed to get job_id {e}")
+        
+    def validate_transaction_with_lock(self, hash_value: str) -> Dict[str, Any]:
+        with alchemy_lock:
+            print(f"Acquired lock: {hash_value}")
+            try:
+                return self.alchemy_kit.get_calls_status(hash_value)
+            except Exception as e:
+                raise Exception(f"Failed to get job_id {e}")
     
     def _sign_transaction(
             self, method_name: str,


### PR DESCRIPTION
This fix here implements a global lock that must be acquired before running any of the calls to Alchemy. This ensures that even if clients don't have their own queue or their own locking mechanism, there will never ever be concurrent calls to Alchemy unless they run 2 different processes using the same wallet address.

Tested this in dev Luna. Sent 100s of job requests concurrently, and the system never hits any of the dreaded
AA23, AA25, callID not found issues ever again. 