### PR TITLE
feat: match ts logic to retry socket connection

### DIFF
--- a/virtuals_acp/client.py
+++ b/virtuals_acp/client.py
@@ -191,6 +191,7 @@ class VirtualsACP:
                 auth=auth_data,
                 headers=headers_data,
                 transports=['websocket'],
+                retry=True
             )
 
             def signal_handler(sig, frame):


### PR DESCRIPTION
match ts logic to reconnect socket after first failed connection

python's default:
```
def connect(self, url, headers={}, auth=None, transports=None,
        namespaces=None, socketio_path='socket.io', wait=True,
        wait_timeout=1, retry=False):
 ```
 
 node's default:
 ```
export interface ManagerOptions extends EngineOptions {
    /**
     * Should we force a new Manager for this connection?
     * @default false
     */
    forceNew: boolean;
    /**
     * Should we multiplex our connection (reuse existing Manager) ?
     * @default true
     */
    multiplex: boolean;
    /**
     * The path to get our client file from, in the case of the server
     * serving it
     * @default '/socket.io'
     */
    path: string;
    /**
     * Should we allow reconnections?
     * @default true
     */
    reconnection: boolean;
    /**
     * How many reconnection attempts should we try?
     * @default Infinity
     */
    reconnectionAttempts: number;
    /**
     * The time delay in milliseconds between reconnection attempts
     * @default 1000
     */
    reconnectionDelay: number;
    /**
     * The max time delay in milliseconds between reconnection attempts
     * @default 5000
     */
    reconnectionDelayMax: number;
    /**
     * Used in the exponential backoff jitter when reconnecting
     * @default 0.5
     */
    randomizationFactor: number;
    /**
     * The timeout in milliseconds for our connection attempt
     * @default 20000
     */
    timeout: number;
    /**
     * Should we automatically connect?
     * @default true
     */
    autoConnect: boolean;
    /**
     * the parser to use. Defaults to an instance of the Parser that ships with socket.io.
     */
    parser: any;
}
 ```