### PR TITLE
feat: use sla minutes from be

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,6 @@ chosen_agent = relevant_agents[0]
 chosen_agent_offering = chosen_agent.offerings[0]
 job_id = chosen_agent_offering.initiate_job(
   service_requirement,
-  expired_at,
   evaluator_address
 )
 

--- a/examples/acp_base/external_evaluation/buyer.py
+++ b/examples/acp_base/external_evaluation/buyer.py
@@ -1,6 +1,5 @@
 import logging
 import threading
-from datetime import datetime, timedelta
 from typing import Optional
 
 from dotenv import load_dotenv
@@ -85,8 +84,7 @@ def buyer():
             "<your-schema-key-1>": "<your-schema-value-1>",
             "<your-schema-key-2>": "<your-schema-value-2>",
         },
-        evaluator_address=env.EVALUATOR_AGENT_WALLET_ADDRESS, # evaluator address
-        expired_at=datetime.now() + timedelta(minutes=3.1)  # job expiry duration, minimum 3 minutes
+        evaluator_address=env.EVALUATOR_AGENT_WALLET_ADDRESS,  # evaluator address
     )
 
     logger.info(f"Job {job_id} initiated")

--- a/examples/acp_base/polling_mode/buyer.py
+++ b/examples/acp_base/polling_mode/buyer.py
@@ -1,6 +1,5 @@
 import logging
 import time
-from datetime import datetime, timedelta
 
 from dotenv import load_dotenv
 
@@ -66,7 +65,6 @@ def buyer():
             "<your-schema-key-2>": "<your-schema-value-2>",
         },
         evaluator_address=env.EVALUATOR_AGENT_WALLET_ADDRESS,  # evaluator address
-        expired_at=datetime.now() + timedelta(minutes=3.1),  # job expiry duration, minimum 3 minutes
     )
 
     logger.info(f"Job {job_id} initiated")

--- a/examples/acp_base/skip_evaluation/buyer.py
+++ b/examples/acp_base/skip_evaluation/buyer.py
@@ -1,6 +1,5 @@
 import logging
 import threading
-from datetime import datetime, timedelta
 from typing import Optional
 
 from dotenv import load_dotenv
@@ -87,7 +86,6 @@ def buyer():
             "<your-schema-key-1>": "<your-schema-value-1>",
             "<your-schema-key-2>": "<your-schema-value-2>",
         },
-        expired_at=datetime.now() + timedelta(minutes=5),  # job expiry duration, minimum 3 minutes
     )
     logger.info(f"Job {job_id} initiated")
     logger.info("Listening for next steps...")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "virtuals-acp"
-version = "0.3.19"
+version = "0.3.20"
 description = "Agent Commerce Protocol Python SDK by Virtuals"
 authors = ["Steven Lee Soon Fatt <steven@virtuals.io>"]
 readme = "README.md"

--- a/tests/unit/test_job_offering.py
+++ b/tests/unit/test_job_offering.py
@@ -56,6 +56,7 @@ class TestACPJobOffering:
             name="Test Service",
             price=10.0,
             price_type=PriceType.FIXED,
+            sla_minutes=60,
             requirement=None,
             deliverable=None
         )
@@ -71,6 +72,7 @@ class TestACPJobOffering:
             name="Test Service",
             price=10.0,
             price_type=PriceType.FIXED,
+            sla_minutes=60,
             requirement={
                 "type": "object",
                 "properties": {
@@ -96,6 +98,7 @@ class TestACPJobOffering:
                 name="Test Service",
                 price=10.0,
                 price_type=PriceType.FIXED,
+                sla_minutes=60,
                 requirement=None,
                 deliverable=None
             )
@@ -123,6 +126,7 @@ class TestACPJobOffering:
                 name="Test Service",
                 price=10.0,
                 price_type=PriceType.PERCENTAGE,
+                sla_minutes=60,
                 requirement=requirement,
                 deliverable=deliverable,
             )
@@ -145,6 +149,7 @@ class TestACPJobOffering:
                 name="Test Service",
                 price=10.0,
                 price_type=PriceType.FIXED,
+                sla_minutes=60,
                 requirement='{"type": "string"}',
                 deliverable=None
             )
@@ -165,6 +170,7 @@ class TestACPJobOffering:
                 name="Test Service",
                 price=10.0,
                 price_type=PriceType.FIXED,
+                sla_minutes=60,
                 requirement=requirement,
                 deliverable=None
             )
@@ -195,10 +201,10 @@ class TestACPJobOffering:
         class TestExpiryHandling:
             """Test expiry date handling"""
 
-            def test_should_use_default_expiry_when_none(
+            def test_should_use_sla_minutes_for_expiry(
                 self, basic_offering, mock_contract_client
             ):
-                """Should use default 1 day expiry when not provided"""
+                """Should use offering sla_minutes for job expiration"""
                 mock_contract_client.get_job_id.return_value = 123
                 mock_contract_client.handle_operation.return_value = {}
                 basic_offering.acp_client.get_by_client_and_provider.return_value = None
@@ -213,34 +219,11 @@ class TestACPJobOffering:
                         service_requirement={"task": "test"}
                     )
 
-                    # Check that create_job was called
                     create_call = mock_contract_client.create_job.call_args
                     expired_at = create_call[0][2]  # Third positional arg
 
-                    # Should be 1 day after now
-                    expected = mock_now + timedelta(days=1)
+                    expected = mock_now + timedelta(minutes=basic_offering.sla_minutes)
                     assert expired_at == expected
-
-            def test_should_use_custom_expiry_when_provided(
-                self, basic_offering, mock_contract_client
-            ):
-                """Should use custom expiry when provided"""
-                mock_contract_client.get_job_id.return_value = 123
-                mock_contract_client.handle_operation.return_value = {}
-                basic_offering.acp_client.get_by_client_and_provider.return_value = None
-
-                custom_expiry = datetime(
-                    2024, 12, 31, 23, 59, 59, tzinfo=timezone.utc)
-
-                basic_offering.initiate_job(
-                    service_requirement={"task": "test"},
-                    expired_at=custom_expiry
-                )
-
-                create_call = mock_contract_client.create_job.call_args
-                expired_at = create_call[0][2]
-
-                assert expired_at == custom_expiry
 
         class TestServiceRequirementValidation:
             """Test service requirement validation"""

--- a/virtuals_acp/client.py
+++ b/virtuals_acp/client.py
@@ -315,6 +315,7 @@ class VirtualsACP:
                     price=price,
                     price_type=price_type,
                     required_funds=offering["requiredFunds"],
+                    sla_minutes=offering["slaMinutes"],
                     requirement=offering.get("requirement", None),
                     deliverable=offering.get("deliverable", None),
                 )

--- a/virtuals_acp/job_offering.py
+++ b/virtuals_acp/job_offering.py
@@ -30,6 +30,7 @@ class ACPJobOffering(BaseModel):
     price: float
     price_type: PriceType
     required_funds: bool
+    sla_minutes: int
     requirement: Optional[Union[Dict[str, Any], str]] = None
     deliverable: Optional[Union[Dict[str, Any], str]] = None
 
@@ -54,10 +55,8 @@ class ACPJobOffering(BaseModel):
         self,
         service_requirement: Union[Dict[str, Any], str],
         evaluator_address: Optional[str] = None,
-        expired_at: Optional[datetime] = None,
     ) -> int:
-        if expired_at is None:
-            expired_at = datetime.now(timezone.utc) + timedelta(days=1)
+        expired_at = datetime.now(timezone.utc) + timedelta(minutes=self.sla_minutes)
 
         # Validate against requirement schema if present
         if self.requirement:
@@ -139,7 +138,7 @@ class ACPJobOffering(BaseModel):
                 evaluator_address or self.contract_client.agent_wallet_address,
                 fare_amount.amount,
                 fare_amount.fare.contract_address,
-                expired_at or datetime.utcnow(),
+                expired_at,
                 is_x402_job=is_x402_job,
             )
 


### PR DESCRIPTION
tested and verified locally

maintained flexibility to set expiry from acpClient.initiateJob but jobOffering.initiateJob should always follow the jobOffering's SLA like job offering price